### PR TITLE
Matchear el primer "por" al leer el kudo

### DIFF
--- a/helpers/interpretar.js
+++ b/helpers/interpretar.js
@@ -1,5 +1,5 @@
 module.exports =  function(body){
-    var mensaje = body.match(/a (.*) por (.*)/i);
+    var mensaje = body.match(/a (.*?) por (.*)/i);
     if(mensaje === null || mensaje.length != 3){
         throw new Error('El formato del Kudo debe ser: `/kudo para [alguien] por [algo]`.');
     } 

--- a/test/separador_test.js
+++ b/test/separador_test.js
@@ -31,5 +31,13 @@ describe('Interpretador', function(){
         expect( iterpretado  ).to.have.property('por', 'ser tan groso');
 
         done();
+    });
+    it('debería tomar el primer "por" cuando hay más de uno', function (done) {
+        var interpretado = interpretar('para mi por ser tan groso y por mi humildad');
+
+        expect(interpretado).to.have.property('para', 'mi');
+        expect(interpretado).to.have.property('por', 'ser tan groso y por mi humildad');
+
+        done();
     })
 });


### PR DESCRIPTION
Arregla #11 

Solución: hacer la parte que precede al "por" _no golosa_: http://stackoverflow.com/questions/2824302/how-to-make-regular-expression-into-non-greedy

Mr @jazcarate review please!