### PR TITLE
Fix para que los logs no dejen de streamear cuando se produce un cambio de ambiente

### DIFF
--- a/app/.ebextensions/01_cloudwatch.config
+++ b/app/.ebextensions/01_cloudwatch.config
@@ -14,6 +14,14 @@ files:
       log_stream_name=`{"Fn::Join":["/", [{ "Ref":"AWSEBEnvironmentName" }, "eb-activity"]]}`
       file=/var/log/eb-activity.log*
 
+  "/opt/elasticbeanstalk/hooks/configdeploy/post/01_restart_logs.sh":
+        mode: "000755"
+        owner: root
+        group: root
+        content: |
+          sudo service awslogs restart
+          echo AWS logs restarted
+
 commands:
   01_restart_aws_logs:
     command: "sudo service awslogs restart"


### PR DESCRIPTION
`awslogs` no se lleva bien con _logrotate_. Esto produce que cambios en la configuración del ambiente hagan que `CloudWatch` deje de recibir eventos.

Añadí una script que corre después de que se hayan aplicados los cambios y reinicia el servicio. Me parece que era lo menos intrusivo y mas consistente.