### PR TITLE
Agrega buscador de kudos segun recipiente

### DIFF
--- a/app/models/Kudo.js
+++ b/app/models/Kudo.js
@@ -66,13 +66,17 @@ Kudo.actualizar = function(id, nuevoKudo, cb){
   return Kudo.findByIdAndUpdate(id, nuevoKudo, cb);
 }
 
-Kudo.encontrarUltimos = function(semanas, cb){
-  var ultimaSemana = moment().subtract(7*semanas, 'days');
-  return Kudo.find({
+Kudo.encontrarKudos = function (semanas, kudoPara, kudoPor, cb) {
+  var ultimaSemana = moment().subtract(7 * semanas, "days");
+  return Kudo.find(
+    {
       updated_at: {
-        $gte: ultimaSemana.toDate()
-      }
-    }, cb);
-}
+        $gte: ultimaSemana.toDate(),
+      },
+      para: { $regex: kudoPara, $options: "i" },
+    },
+    cb
+  );
+};
 
 module.exports = Kudo;

--- a/app/public/stylesheets/style.css
+++ b/app/public/stylesheets/style.css
@@ -119,10 +119,10 @@ header .logo {
   box-sizing: border-box;
 }
 
-#semanas {
+#buscadores {
   display: none;
 }
 
-#logo:hover #semanas {
+#logo:hover #buscadores {
   display: block;
 }

--- a/app/routes/kudos.js
+++ b/app/routes/kudos.js
@@ -16,14 +16,14 @@ router.get('/:id', function(req, res, next) {
   });
 });
 
-router.get('/', function(req, res, next){
-  debugger;
+router.get("/", function (req, res, next) {
   const semanas = req.query.semanas || 1;
-  Kudo.encontrarUltimos(semanas, function (err, kudos) {
+  const kudoPara = req.query.kudoPara || "";
+  Kudo.encontrarKudos(semanas, kudoPara, function (err, kudos) {
     if (err) return next(err);
 
-    res.render('index', { kudos: kudos });
-  }).sort({updated_at: 'desc'});
+    res.render("index", { kudos: kudos });
+  }).sort({ updated_at: "desc" });
 });
 
 router.post('/nuevo', function(req, res, next) {

--- a/app/test/kudo_test.js
+++ b/app/test/kudo_test.js
@@ -46,7 +46,7 @@ describe('Kudo', function(){
       it('crear dos kudos repetidos, y que solo aparezca uno', function(done){
           Kudo.armar('para mi por tantas cosas', 'yo', function(kudoCreado){
             Kudo.armar('para mi por tantas cosas', 'yo', function(kudoDuplicado){
-              Kudo.encontrarUltimos(1, function(err, kudos){
+              Kudo.encontrarKudos(1, "", function(err, kudos){
                 expect(kudos).to.have.length(1);
                 done();
               });

--- a/app/views/layouts/main.handlebars
+++ b/app/views/layouts/main.handlebars
@@ -14,6 +14,7 @@
       <img class="logo" src="imagenes/10pines-logo.png"/>
       <div id="logo">
         <img src="imagenes/kudowall-logo.png" />
+        <div id="buscadores">
           <div id="semanas">
             <form method="GET" action="/">
               <label for="semanas">Semanas: </label>
@@ -21,6 +22,14 @@
               <input type="submit" value="Ver" />
             </form>
           </div>
+          <div id="kudoPara">
+            <form method="GET" action="/">
+              <label for="kudoPara">Kudo para: </label>
+              <input type="text" name="kudoPara" size="2" />
+              <input type="submit" value="Buscar" />
+            </form>
+          </div>
+        </div>
       </div>
   </header>
 


### PR DESCRIPTION
La idea de esto es que se pueda tener más facil un archivo de todos los kudos que recibio X pine. Lo busca con un `LIKE %texto%`, para que buscar `fede` devuelva todos los kudos para `fede` `fedex` `@fede`, etc

![image](https://user-images.githubusercontent.com/25667102/89349152-1c79e880-d684-11ea-81e2-e391ff87de90.png)

![image](https://user-images.githubusercontent.com/25667102/89349170-256aba00-d684-11ea-86e8-de33b8d365b7.png)
