### PR TITLE
Hacer que no se escape el texto sanitizado de los kudos en la vista

### DIFF
--- a/app/views/partials/kudo.handlebars
+++ b/app/views/partials/kudo.handlebars
@@ -4,5 +4,5 @@
 </div>
 
 <script>
-    dibujarKudo("kudo-{{id}}", "{{por}}", "{{para}}", "{{autor}}");
+    dibujarKudo("kudo-{{id}}", "{{{por}}}", "{{{para}}}", "{{autor}}");
 </script>


### PR DESCRIPTION
Esto es para que no se muestren el texto escapeado (`&amp;` en lugar de `&`). No debería ser necesario ya que se sanitiza antes.